### PR TITLE
Issue 389

### DIFF
--- a/files_test.go
+++ b/files_test.go
@@ -141,4 +141,13 @@ func TestUploadFile(t *testing.T) {
 	if _, err := api.UploadFile(params); err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
+
+	largeByt := make([]byte, 1073742000*3)
+	reader = bytes.NewBuffer(largeByt)
+	params = FileUploadParameters{
+		Filename: "test.txt", Reader: reader,
+		Channels: []string{"CXXXXXXXX"}}
+	if _, err := api.UploadFile(params); err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
 }

--- a/files_test.go
+++ b/files_test.go
@@ -142,7 +142,7 @@ func TestUploadFile(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err)
 	}
 
-	largeByt := make([]byte, 1073742000*3)
+	largeByt := make([]byte, 107374200)
 	reader = bytes.NewBuffer(largeByt)
 	params = FileUploadParameters{
 		Filename: "test.txt", Reader: reader,

--- a/misc.go
+++ b/misc.go
@@ -64,23 +64,22 @@ func (e *RateLimitedError) Error() string {
 	return fmt.Sprintf("Slack rate limit exceeded, retry after %s", e.RetryAfter)
 }
 
-func fileUploadReq(ctx context.Context, path, fieldname, filename string, values url.Values, r io.Reader) (*http.Request, error) {
-	body := &bytes.Buffer{}
-	wr := multipart.NewWriter(body)
 
-	ioWriter, err := wr.CreateFormFile(fieldname, filename)
-	if err != nil {
-		wr.Close()
-		return nil, err
-	}
-	_, err = io.Copy(ioWriter, r)
-	if err != nil {
-		wr.Close()
-		return nil, err
-	}
-	// Close the multipart writer or the footer won't be written
-	wr.Close()
-	req, err := http.NewRequest("POST", path, body)
+func fileUploadReq(ctx context.Context, path, fieldname, filename string, values url.Values, r io.Reader) (*http.Request, error) {
+	pipeReader, pipeWriter := io.Pipe()
+	wr := multipart.NewWriter(pipeWriter)
+	go func() {
+		defer pipeWriter.Close()
+		ioWriter, err := wr.CreateFormFile(fieldname, filename)
+		if err != nil {
+		}
+		_, err = io.Copy(ioWriter, r)
+		if err != nil {
+		}
+		if err := wr.Close(); err != nil {
+		}
+	}()
+	req, err := http.NewRequest("POST", path, pipeReader)
 	req = req.WithContext(ctx)
 	if err != nil {
 		return nil, err

--- a/misc.go
+++ b/misc.go
@@ -64,29 +64,13 @@ func (e *RateLimitedError) Error() string {
 	return fmt.Sprintf("Slack rate limit exceeded, retry after %s", e.RetryAfter)
 }
 
-func fileUploadReq(ctx context.Context, path, fieldname, filename string, values url.Values, r io.Reader) (*http.Request, error) {
-	pipeReader, pipeWriter := io.Pipe()
-	wr := multipart.NewWriter(pipeWriter)
-	go func() {
-		defer pipeWriter.Close()
-		ioWriter, err := wr.CreateFormFile(fieldname, filename)
-		if err != nil {
-			fmt.Println(err)
-		}
-		_, err = io.Copy(ioWriter, r)
-		if err != nil {
-			fmt.Println(err)
-		}
-		if err := wr.Close(); err != nil {
-			fmt.Println(err)
-		}
-	}()
-	req, err := http.NewRequest("POST", path, pipeReader)
+func fileUploadReq(ctx context.Context, path string, values url.Values, r io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest("POST", path, r)
+
 	req = req.WithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Content-Type", wr.FormDataContentType())
 	req.URL.RawQuery = (values).Encode()
 	return req, nil
 }
@@ -119,12 +103,34 @@ func postLocalWithMultipartResponse(ctx context.Context, client HTTPRequester, p
 }
 
 func postWithMultipartResponse(ctx context.Context, client HTTPRequester, path, name, fieldname string, values url.Values, r io.Reader, intf interface{}, debug bool) error {
-	req, err := fileUploadReq(ctx, SLACK_API+path, fieldname, name, values, r)
+	pipeReader, pipeWriter := io.Pipe()
+	wr := multipart.NewWriter(pipeWriter)
+	errc := make(chan error)
+	go func() {
+		defer pipeWriter.Close()
+		ioWriter, err := wr.CreateFormFile(fieldname, name)
+		if err != nil {
+			errc <- err
+			return
+		}
+		_, err = io.Copy(ioWriter, r)
+		if err != nil {
+			errc <- err
+			return
+		}
+		if err = wr.Close(); err != nil {
+			errc <- err
+			return
+		}
+	}()
+	req, err := fileUploadReq(ctx, SLACK_API+path, values, pipeReader)
 	if err != nil {
 		return err
 	}
+	req.Header.Add("Content-Type", wr.FormDataContentType())
 	req = req.WithContext(ctx)
 	resp, err := client.Do(req)
+
 	if err != nil {
 		return err
 	}
@@ -143,8 +149,12 @@ func postWithMultipartResponse(ctx context.Context, client HTTPRequester, path, 
 		logResponse(resp, debug)
 		return statusCodeError{Code: resp.StatusCode, Status: resp.Status}
 	}
-
-	return parseResponseBody(resp.Body, intf, debug)
+	select {
+	case err = <-errc:
+		return err
+	default:
+		return parseResponseBody(resp.Body, intf, debug)
+	}
 }
 
 func doPost(ctx context.Context, client HTTPRequester, req *http.Request, intf interface{}, debug bool) error {

--- a/misc.go
+++ b/misc.go
@@ -64,7 +64,6 @@ func (e *RateLimitedError) Error() string {
 	return fmt.Sprintf("Slack rate limit exceeded, retry after %s", e.RetryAfter)
 }
 
-
 func fileUploadReq(ctx context.Context, path, fieldname, filename string, values url.Values, r io.Reader) (*http.Request, error) {
 	pipeReader, pipeWriter := io.Pipe()
 	wr := multipart.NewWriter(pipeWriter)
@@ -72,11 +71,14 @@ func fileUploadReq(ctx context.Context, path, fieldname, filename string, values
 		defer pipeWriter.Close()
 		ioWriter, err := wr.CreateFormFile(fieldname, filename)
 		if err != nil {
+			fmt.Println(err)
 		}
 		_, err = io.Copy(ioWriter, r)
 		if err != nil {
+			fmt.Println(err)
 		}
 		if err := wr.Close(); err != nil {
+			fmt.Println(err)
 		}
 	}()
 	req, err := http.NewRequest("POST", path, pipeReader)


### PR DESCRIPTION
#389 
I change io.Copy to io.Pipe in fileUploadReq for posting large file.
it reduces the latecy of post large file, refere to the test.
before(master)
```
[u5@ik1-321-20921 slack]$ go test ./...
ok      github.com/nlopes/slack 35.593s
?       github.com/nlopes/slack/examples/channels       [no test files]
?       github.com/nlopes/slack/examples/eventsapi      [no test files]
?       github.com/nlopes/slack/examples/files  [no test files]
?       github.com/nlopes/slack/examples/groups [no test files]
?       github.com/nlopes/slack/examples/ims    [no test files]
?       github.com/nlopes/slack/examples/messages       [no test files]
?       github.com/nlopes/slack/examples/pins   [no test files]
?       github.com/nlopes/slack/examples/reactions      [no test files]
?       github.com/nlopes/slack/examples/slash  [no test files]
?       github.com/nlopes/slack/examples/stars  [no test files]
?       github.com/nlopes/slack/examples/team   [no test files]
?       github.com/nlopes/slack/examples/users  [no test files]
?       github.com/nlopes/slack/examples/websocket      [no test files]
ok      github.com/nlopes/slack/slackevents     0.005s
ok      github.com/nlopes/slack/slackutilsx     0.015s
```
after(issue-389)
```
% go test ./...
ok      github.com/nlopes/slack 0.192s
?       github.com/nlopes/slack/examples/channels       [no test files]
?       github.com/nlopes/slack/examples/eventsapi      [no test files]
?       github.com/nlopes/slack/examples/files  [no test files]
?       github.com/nlopes/slack/examples/groups [no test files]
?       github.com/nlopes/slack/examples/ims    [no test files]
?       github.com/nlopes/slack/examples/messages       [no test files]
?       github.com/nlopes/slack/examples/pins   [no test files]
?       github.com/nlopes/slack/examples/reactions      [no test files]
?       github.com/nlopes/slack/examples/slash  [no test files]
?       github.com/nlopes/slack/examples/stars  [no test files]
?       github.com/nlopes/slack/examples/team   [no test files]
?       github.com/nlopes/slack/examples/users  [no test files]
?       github.com/nlopes/slack/examples/websocket      [no test files]
ok      github.com/nlopes/slack/slackevents     0.005s
ok      github.com/nlopes/slack/slackutilsx     0.002s
```